### PR TITLE
Add support for route argument when mounting meddleware.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ var http = require('http'),
     config = require('shush')('./config/middleware');
 
 var app = express();
-app.use(meddleware(config));
+app.use(meddleware(config)); // or app.use('/foo', meddleware(config));
 http.createServer(app).listen(8080);
 
 ```

--- a/test/fixtures/routes.json
+++ b/test/fixtures/routes.json
@@ -18,7 +18,7 @@
         "enabled": true,
         "priority": 70,
         "module": "./fixtures/middleware/routes",
-        "route": "/bar",
+        "route": "bar",
         "arguments": null
     }
 }


### PR DESCRIPTION
Currently, if someone chooses to use meddleware with a particular root path, routes will not resolve correctly.

This PR adds support for specifying a base route when using this module.

``` javascript
app.use('/foo', meddleware(config));
```

and effectively is the same to doing

``` javascript
app.use('/foo', express.cookieParser());
// etc...
```
