### PR TITLE
pegging serve-static to ^1.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jshint": "^2.5.0",
     "morgan": "^1.0.0",
     "serve-favicon": "^2.0.1",
-    "serve-static": "^1.0.4",
+    "serve-static": "^1.5.4",
     "shortstop": "^1.0.1",
     "shortstop-handlers": "^1.0.0",
     "supertest": "^0.11.0",

--- a/test/fixtures/defaults.json
+++ b/test/fixtures/defaults.json
@@ -8,7 +8,7 @@
         }
     },
 
-    "static": {
+    "serveStatic": {
         "enabled": true,
         "priority": 30,
         "module": {

--- a/test/meddleware.js
+++ b/test/meddleware.js
@@ -91,7 +91,7 @@ test('priority', function (t) {
             entry = app._router.stack[3];
             t.ok(entry, 'position 3 middleware exists');
             t.equal(typeof entry.handle, 'function', 'position 3 middleware is a function');
-            t.equal(entry.handle.name, 'staticMiddleware', 'position 3 middleware has the expected name');
+            t.equal(entry.handle.name, 'serveStatic', 'position 3 middleware has the expected name');
 
             entry = app._router.stack[4];
             t.ok(entry, 'position 4 middleware exists');


### PR DESCRIPTION
`serve-static@1.5.4` (specifically, expressjs/serve-static@62194ad1dcb1828f2e0f6c91a5d9ad861e6810f3) introduced an internal change that broke our tests.
