### PR TITLE
update value of name in custom middleware example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ http.createServer(app).listen(8080);
         "priority": 30,
         "route": "/foo",
         "module": {
-            "name": "./lib/middleware",
+            "name": "path:./lib/middleware",
             "method": "customMiddleware",
             "arguments": [ "foo", { "bar": "baz" } ]
         }


### PR DESCRIPTION
in trying to add a custom middleware to the config, i needed to add a `path:` shortstop handler for the module to the name property.

this is just an update to the README to reflect that.
