### PR TITLE
add array `route` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,19 @@ http.createServer(app).listen(8080);
         }
     },
 
+    "security": {
+        "enabled": true,
+        "priority": 40,
+        "route": [ "/foo", "/bar" ],
+        "module": {
+            "name": "./lib/security",
+            "arguments": [ { "maximum": true } ]
+        }
+    },
+
     "cookieParser": {
         "enabled": false,
-        "priority": 40,
+        "priority": 50,
         "module": {
             "name": "cookie-parser",
             "arguments": [ "keyboard cat" ]
@@ -64,7 +74,7 @@ http.createServer(app).listen(8080);
     },
 
     "misc": {
-        "priority": 50,
+        "priority": 60,
         "parallel": {
             "user": {
                 "enabled": true,

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ http.createServer(app).listen(8080);
 are registered first, while higher numbers are registered later. If `priority` is not a number, this setting defaults
 to `Number.MIN_VALUE`.
 
-- `module` (*object*, *string*) - The name or definition of the module to load containing the middleware implementation. Can be an installed module or a path to a module file within your project/application.
+- `module` (*object* **or** *string*) - The name or definition of the module to load containing the middleware implementation. Can be an installed module or a path to a module file within your project/application.
 
     - `name` (*string*) - The name of the module or path to local module.
 
@@ -104,7 +104,32 @@ to `Number.MIN_VALUE`.
 
     - `arguments` (*array*, optional) - An array of arguments to pass to the middleware factory.
 
-- `route` (*string*, *array*, *regexp*, optional) - An express route against which the middleware should be registered. Please note that—if configuring `meddleware` with json files—you'll need to use something like [shortstop](https://github.com/krakenjs/shortstop) with [shortstop-regex](https://github.com/jasisk/shortstop-regex) to convert a string to RegExp.
+- `route` (*string* **or** *array* **or** *regexp*, optional) - An express route against which the middleware should be registered. Can be a string or a regular expression, or an array consisting of strings and regular expressions.
+
+  ##### Caveats
+
+  1. If configuring meddleware with json files, you'll need to use something like [shortstop](https://github.com/krakenjs/shortstop) with [shortstop-regex](https://github.com/jasisk/shortstop-regex) to convert a `string` to `RegExp`.
+
+  2. String paths will be automatically prefixed with any `mountpath` but regular expressions will not.
+
+    ``` js
+    var config = {
+      myMiddleware: {
+        module: './myMiddleware',
+        route: '/foo'
+      },
+      otherMiddleware: {
+        module: './otherMiddleware',
+        route: /^\/bar$/i
+      }
+    }
+
+    app.use('/baz', meddleware(config));
+
+    // `myMiddleware` will run on `/baz/foo`
+    // `otherMiddleware` will run on `/bar`
+    ```
+
 
 - `parallel` (*object*, optional) - A meddleware configuration object containing middleware which should be executed in parallel, proceeding only when all have completed.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ to `Number.MIN_VALUE`.
 
     - `arguments` (*array*, optional) - An array of arguments to pass to the middleware factory.
 
-- `route` (*string*, *RegExp*, optional) - An express route against which the middleware should be registered. Please note that—if configuring `meddleware` with json files—you'll need to use something like [shortstop](https://github.com/krakenjs/shortstop) with [shortstop-regex](https://github.com/jasisk/shortstop-regex) to convert a string to RegExp.
+- `route` (*string*, *array*, *regexp*, optional) - An express route against which the middleware should be registered. Please note that—if configuring `meddleware` with json files—you'll need to use something like [shortstop](https://github.com/krakenjs/shortstop) with [shortstop-regex](https://github.com/jasisk/shortstop-regex) to convert a string to RegExp.
 
 - `parallel` (*object*, optional) - A meddleware configuration object containing middleware which should be executed in parallel, proceeding only when all have completed.
 

--- a/index.js
+++ b/index.js
@@ -197,8 +197,14 @@ module.exports = function meddleware(settings) {
                 fn = resolve(spec, spec.name);
                 eventargs = { app: parent, config: spec };
 
-                route = normalize(mountpath, spec.route);
-
+                if (thing.isArray(spec.route)) {
+                    route = spec.route.map(function (route) {
+                        return normalize(mountpath, route);
+                    });
+                } else {
+                    route = normalize(mountpath, spec.route);
+                }
+                
                 debug('registering', spec.name, 'middleware');
 
                 parent.emit('middleware:before', eventargs);

--- a/index.js
+++ b/index.js
@@ -144,6 +144,28 @@ function compare(a, b) {
 }
 
 
+/**
+ * Normalize string routes
+ * @param mountpath
+ * @param route
+ * @returns {string}
+ */
+function normalize(mountpath, route) {
+
+    if (thing.isRegExp(route)) {
+        // we cannot normalize regexes
+        return route;
+    }
+
+    if (thing.isString(route)) {
+        mountpath += mountpath[mountpath.length - 1] !== '/' ? '/' : '';
+        mountpath += route[0] === '/' ? route.slice(1) : route;
+    }
+
+    return mountpath;
+}
+
+
 module.exports = function meddleware(settings) {
     var basedir, app;
 
@@ -175,11 +197,7 @@ module.exports = function meddleware(settings) {
                 fn = resolve(spec, spec.name);
                 eventargs = { app: parent, config: spec };
 
-                route = thing.isRegExp(spec.route) ? spec.route : mountpath;
-                if (thing.isString(spec.route)) {
-                    route += route[route.length - 1] !== '/' ? '/' : '';
-                    route += spec.route[0] === '/' ? spec.route.slice(1) : spec.route;
-                }
+                route = normalize(mountpath, spec.route);
 
                 debug('registering', spec.name, 'middleware');
 

--- a/test/fixtures/array-routes.json
+++ b/test/fixtures/array-routes.json
@@ -1,0 +1,40 @@
+{
+    "routeA": {
+        "enabled": true,
+        "priority": 50,
+        "module": {
+            "name": "./fixtures/middleware/routes",
+            "method": "routeA"
+        },
+        "route": ["/foo"]
+    },
+
+    "routeB": {
+        "enabled": true,
+        "priority": 60,
+        "module": {
+            "name": "./fixtures/middleware/routes",
+            "method": "routeB"
+        }
+    },
+
+    "routeC": {
+        "enabled": true,
+        "priority": 70,
+        "module": {
+            "name": "./fixtures/middleware/routes",
+            "method": "routeC"
+        },
+        "route": [ "/foo", "/bar" ]
+    },
+
+    "routeD": {
+        "enabled": true,
+        "priority": 80,
+        "module": {
+            "name": "./fixtures/middleware/routes",
+            "method": "routeD"
+        },
+        "route": [ "/bar", "regex:^\/baz$" ]
+    }
+}

--- a/test/meddleware.js
+++ b/test/meddleware.js
@@ -386,6 +386,73 @@ test('routes', function (t) {
     });
 
 
+    t.test('route-specific middleware (arrays)', function (t) {
+        var config, app;
+
+        function req(route, cb) {
+            var server;
+            server = request(app)
+                .get(route)
+                .end(function (err, res) {
+                    t.error(err, 'no response error');
+                    t.equal(typeof res, 'object', 'response is defined');
+                    t.equal(typeof res.body, 'object', 'response body is defined');
+                    cb(res.body);
+                });
+        }
+
+        config = require('./fixtures/array-routes');
+        resolve(config, function (err, config) {
+            app = express();
+            app.use(meddle(config));
+
+            app.get('/', function (req, res) {
+                t.notOk(res.locals.routeA);
+                t.ok(res.locals.routeB);
+                t.notOk(res.locals.routeC);
+                t.notOk(res.locals.routeD);
+                res.status(200).end();
+            });
+
+            app.get('/foo', function (req, res) {
+                t.ok(res.locals.routeA);
+                t.ok(res.locals.routeB);
+                t.ok(res.locals.routeC);
+                t.notOk(res.locals.routeD);
+                res.status(200).end();
+            });
+
+            app.get('/bar', function (req, res) {
+                t.notOk(res.locals.routeA);
+                t.ok(res.locals.routeB);
+                t.ok(res.locals.routeC);
+                t.ok(res.locals.routeD);
+                res.status(200).end();
+            });
+
+            app.get('/baz', function (req, res) {
+                t.notOk(res.locals.routeC);
+                t.notOk(res.locals.routeA);
+                t.ok(res.locals.routeB);
+                t.ok(res.locals.routeD);
+                res.status(200).end();
+            });
+
+            // trololol
+            req('/', function () {
+                req('/foo', function () {
+                    req('/bar', function () {
+                        req('/baz', function () {
+                            t.end();
+                        });
+                    });
+                });
+            });
+        });
+
+    });
+
+
     t.test('baseroute route-specific middleware', function (t) {
         var config, app;
 
@@ -434,6 +501,75 @@ test('routes', function (t) {
             req('/bam/foo', function () {
                 req('/bam/bar', function () {
                     t.end();
+                });
+            });
+        });
+
+    });
+
+
+    t.test('baseroute route-specific middleware (arrays)', function (t) {
+        var config, app;
+
+        function req(route, cb) {
+            var server;
+            server = request(app)
+                .get(route)
+                .expect(200)
+                .end(function (err, res) {
+                    t.error(err, 'no response error');
+                    t.equal(typeof res, 'object', 'response is defined');
+                    t.equal(typeof res.body, 'object', 'response body is defined');
+                    cb(res.body);
+                });
+        }
+
+        config = require('./fixtures/array-routes');
+
+        resolve(config, function (err, config) {
+            app = express();
+            app.use('/bam', meddle(config));
+
+            app.get('/bam', function (req, res) {
+                t.notOk(res.locals.routeA);
+                t.ok(res.locals.routeB);
+                t.notOk(res.locals.routeC);
+                t.notOk(res.locals.routeD);
+                res.status(200).end();
+            });
+
+            app.get('/bam/foo', function (req, res) {
+                t.ok(res.locals.routeA);
+                t.ok(res.locals.routeB);
+                t.ok(res.locals.routeC);
+                t.notOk(res.locals.routeD);
+                res.status(200).end();
+            });
+
+            app.get('/bam/bar', function (req, res) {
+                t.notOk(res.locals.routeA);
+                t.ok(res.locals.routeB);
+                t.ok(res.locals.routeC);
+                t.ok(res.locals.routeD);
+                res.status(200).end();
+            });
+
+            app.get('/baz', function (req, res) {
+                t.notOk(res.locals.routeA);
+                t.notOk(res.locals.routeB);
+                t.notOk(res.locals.routeC);
+                t.ok(res.locals.routeD);
+                res.status(200).end();
+            });
+
+            // trololol
+            req('/bam', function () {
+                req('/bam/foo', function () {
+                    req('/bam/bar', function () {
+                        req('/baz', function () {
+                            t.end();
+                        });
+                    });
                 });
             });
         });


### PR DESCRIPTION
This gives us a better whitelist pattern in the sense that we can register a
piece of middleware against multiple routes at once using an `Array` instead
of being forced to use a `RegExp` or pseudo-`RegExp`.
