### PR TITLE
`nameObject` fails when `obj` is a function on node 0.12

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -47,7 +47,7 @@ exports.mapValues = function mapValues(obj, fn) {
  * @returns {*}
  */
 exports.nameObject = function nameObject(obj, name) {
-    obj && (obj.name = name);
+    obj && (typeof obj !== 'function') && (obj.name = name);
     return obj;
 };
 


### PR DESCRIPTION
After upgrading to node 0.12.2, `exports.nameObject` fails if `obj` is a function https://github.com/krakenjs/meddleware/blob/v3.x/lib/util.js#L50
- Error is => 'Possibly unhandled TypeError: Cannot assign to read
  only property 'name' of function' (...)
