### PR TITLE
fix regression: `enabled` toggle for composed sections

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ function resolvery(basedir) {
     return function resolve(spec, name) {
         var fns, fn;
 
+        if (!spec.enabled && 'enabled' in spec) {
+            return;
+        }
+
         spec.name = spec.name || name;
 
         if (spec.parallel) {
@@ -106,6 +110,7 @@ function resolveImpl(root, config) {
  * @returns {Function}
  */
 function middleware(requestory, fns) {
+    fns = fns.filter(function (fn) { return !!fn; });
     var rq = requestory(fns.map(taskery));
     return function composite(req, res, next) {
         function complete(success, failure) {
@@ -190,11 +195,10 @@ module.exports = function meddleware(settings) {
             .forEach(function register(spec) {
                 var fn, eventargs, route;
 
-                if (!spec.enabled && 'enabled' in spec) {
+                if (!(fn = resolve(spec, spec.name))) {
                     return;
                 }
 
-                fn = resolve(spec, spec.name);
                 eventargs = { app: parent, config: spec };
 
                 if (thing.isArray(spec.route)) {

--- a/test/fixtures/middleware/parallel.js
+++ b/test/fixtures/middleware/parallel.js
@@ -23,3 +23,10 @@ exports.middlewareC = function () {
         setTimeout(next, 100);
     };
 };
+
+exports.middlewareD = function () {
+    return function parallelC(req, res, next) {
+        res.locals.parallelD = true;
+        next();
+    };
+};

--- a/test/fixtures/parallel.json
+++ b/test/fixtures/parallel.json
@@ -42,6 +42,13 @@
                     "name": "./fixtures/middleware/parallel",
                     "method": "middlewareC"
                 }
+            },
+            "middlewareD": {
+                "enabled": false,
+                "module": {
+                    "name": "./fixtures/middleware/parallel",
+                    "method": "middlewareD"
+                }
             }
         }
     }

--- a/test/meddleware.js
+++ b/test/meddleware.js
@@ -604,6 +604,7 @@ test('composition', function (t) {
             t.ok(res.locals.parallelA);
             t.ok(res.locals.parallelB);
             t.ok(res.locals.parallelC);
+            t.notOk(res.locals.parallelD);
             res.status(200).end();
         });
 


### PR DESCRIPTION
Closes #59

In at least v1.0.0, we allowed middleware within nested control flow structures to be toggled individually. Given that we still have an example of that working in our documentation, I'm calling this a regression.
