### PR TITLE
mount a router instead of normalizing mountpath

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var thing = require('core-util-is');
 var debug = require('debuglog')('meddleware');
 var RQ = require('./lib/rq');
 var util = require('./lib/util');
-
+var Router = require('express').Router;
 
 /**
  * Creates a middleware resolver based on the provided basedir.
@@ -180,13 +180,14 @@ module.exports = function meddleware(settings) {
     basedir = path.dirname(caller());
 
     function onmount(parent) {
-        var resolve, mountpath;
+        var resolve, mountpath, router;
 
         // Remove the sacrificial express app.
         parent._router.stack.pop();
 
         resolve = resolvery(basedir);
         mountpath = app.mountpath;
+        router = new Router();
 
         util
             .mapValues(settings, util.nameObject)
@@ -201,22 +202,14 @@ module.exports = function meddleware(settings) {
 
                 eventargs = { app: parent, config: spec };
 
-                if (thing.isArray(spec.route)) {
-                    route = spec.route.map(function (route) {
-                        return normalize(mountpath, route);
-                    });
-                } else {
-                    route = normalize(mountpath, spec.route);
-                }
-                
-                debug('registering', spec.name, 'middleware');
-
                 parent.emit('middleware:before', eventargs);
                 parent.emit('middleware:before:' + spec.name, eventargs);
-                parent.use(route, fn);
+                router.use(spec.route || '/', fn);
                 parent.emit('middleware:after:' + spec.name, eventargs);
                 parent.emit('middleware:after', eventargs);
             });
+
+        parent.use(mountpath, router);
     }
 
     app = express();

--- a/index.js
+++ b/index.js
@@ -149,28 +149,6 @@ function compare(a, b) {
 }
 
 
-/**
- * Normalize string routes
- * @param mountpath
- * @param route
- * @returns {string}
- */
-function normalize(mountpath, route) {
-
-    if (thing.isRegExp(route)) {
-        // we cannot normalize regexes
-        return route;
-    }
-
-    if (thing.isString(route)) {
-        mountpath += mountpath[mountpath.length - 1] !== '/' ? '/' : '';
-        mountpath += route[0] === '/' ? route.slice(1) : route;
-    }
-
-    return mountpath;
-}
-
-
 module.exports = function meddleware(settings) {
     var basedir, app;
 

--- a/test/fixtures/routes.json
+++ b/test/fixtures/routes.json
@@ -25,7 +25,7 @@
             "name": "./fixtures/middleware/routes",
             "method": "routeC"
         },
-        "route": "bar"
+        "route": "/bar"
     },
 
     "routeD": {


### PR DESCRIPTION
with this change, `meddleware` will now return an express `Router` instance
instead of mounting middleware directly on the `app` instance.

This enables us to leverage the existing route resolution as provided by
express instead of having to try to compose the path ourselves using the
`app.mountpath`.

This change will prevent error handling middleware from operating globally
and, instead, will scope them to other middleware and route handlers
defined within the same meddleware router instance.
