### PR TITLE
meddleware deployed outside app's node_module can now resolve app's middleware modules deployed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@ html-report
 xunit.xml
 node_modules
 npm-debug.log
+package-lock.json
 
+.vscode
 .project
 .idea
 .settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
-  - "6"
   - "8"
+  - "10"
+  - "12"
 script:
   - "npm run cover"
   - "npm run lint"

--- a/lib/util.js
+++ b/lib/util.js
@@ -15,6 +15,7 @@
  \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
 
+var path = require('path');
 
 /**
  * Returns true if the obj is and express-like instance, otherwise false.
@@ -57,10 +58,19 @@ exports.nameObject = function nameObject(obj, name) {
  * @param module The file path to the desired module.
  * @returns {*} The absolute path to the module or `undefined` if not found.
  */
-exports.tryResolve = function tryResolve(module) {
-    try {
-        return require.resolve(module);
-    } catch (e) {
-        return undefined;
+exports.tryResolve = (function resolver(paths) {
+    // If meddleware module is deployed outside the app's node_modules, it wouldn't be
+    // able to resolve middleware modules deployed under app. Adding app's node_modules 
+    // folder to the paths will help handle this case.
+    var appNodeModules = path.resolve(process.cwd(), 'node_modules');
+    if (paths.indexOf(appNodeModules) < 0) {
+        paths.push(appNodeModules);
     }
-};
+    return function tryResolve(module) {
+        try {
+            return require.resolve(module, { paths: paths });
+        } catch (e) {
+            return undefined;
+        }
+    };
+})(module.paths.slice(0));

--- a/package.json
+++ b/package.json
@@ -24,24 +24,24 @@
     }
   ],
   "devDependencies": {
-    "body-parser": "^1.0.2",
-    "cookie-parser": "^1.0.1",
-    "express": "^4.6.1",
-    "istanbul": "^0.2.7",
-    "jshint": "^2.5.0",
-    "morgan": "^1.0.0",
-    "serve-favicon": "^2.0.1",
-    "serve-static": "^1.0.4",
-    "shortstop": "^1.0.1",
-    "shortstop-handlers": "^1.0.0",
+    "body-parser": "^1.19.0",
+    "cookie-parser": "^1.4.5",
+    "express": "^4.17.1",
+    "istanbul": "^0.4.5",
+    "jshint": "^2.11.0",
+    "morgan": "^1.10.0",
+    "serve-favicon": "^2.5.0",
+    "serve-static": "^1.14.1",
+    "shortstop": "^1.0.3",
+    "shortstop-handlers": "^1.0.1",
     "shortstop-regex": "0.0.1",
-    "supertest": "^0.11.0",
-    "tape": "^2.12.3"
+    "supertest": "^4.0.2",
+    "tape": "^4.13.2"
   },
   "dependencies": {
-    "caller": "0.0.1",
-    "debuglog": "0.0.4",
-    "core-util-is": "^1.0.1"
+    "caller": "1.0.1",
+    "debuglog": "1.0.1",
+    "core-util-is": "^1.0.2"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/apps/test1/index.js
+++ b/test/fixtures/apps/test1/index.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var express = require('express'),
+    assert = require('assert'),
+    request = require('supertest'),
+    meddle = require('../../../../');
+
+var config = {
+  "testMiddlewareContext": {
+      "enabled": true,
+      "priority": 10,
+      "module": {
+          "name": "middleware",
+          "method": "context"
+      }
+  }
+};
+
+function req(route, cb) {
+  var server;
+  server = request(app)
+      .get(route)
+      .end(function (err, res) {
+          assert(!err, 'expected no response error');
+          assert.strictEqual(typeof res, 'object', 'response is defined');
+          assert.strictEqual(typeof res.body, 'object', 'response body is defined');
+          cb(res.body);
+      });
+}
+
+var app = express();
+app.use(meddle(config));
+
+app.get('/', function (req, res) {
+    assert(res.locals.selfWasCalled,'The method was called with a scope');
+    res.status(200).end();
+});
+
+req('/', function () {
+    console.log('success!!!');
+});

--- a/test/fixtures/apps/test1/package.json
+++ b/test/fixtures/apps/test1/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "middleware": "file:../../middleware"
+  }
+}

--- a/test/fixtures/middleware/index.js
+++ b/test/fixtures/middleware/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var context = require('./context');
+
+module.exports = {
+    context: context.run.bind(context),
+};

--- a/test/fixtures/middleware/package.json
+++ b/test/fixtures/middleware/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "middleware",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/meddleware.js
+++ b/test/meddleware.js
@@ -7,6 +7,10 @@ var test = require('tape'),
     shortstop = require('shortstop'),
     handlers = require('shortstop-handlers'),
     ssRegex = require('shortstop-regex'),
+    path = require('path'),
+    util = require('util'),
+    child_process = require('child_process'),
+    exec = util.promisify(child_process.exec),
     meddle = require('../');
 
 function Resolver() {
@@ -738,6 +742,25 @@ test('use module as context in factory method', function (t) {
         });
 
         req('/', function () {
+            t.end();
+        });
+    });
+});
+
+test('test util.tryResolve', function (t) {
+    t.test('meddleware module outside the app\'s directory trying to resolve middleware module deployed inside', function (t) {
+        var testAppPath = path.join(__dirname, 'fixtures', 'apps', 'test1');
+        var options = { cwd: testAppPath };
+        exec('rm -rf node_modules/', options).then(function () {
+            return exec('npm --package-lock=false install', options);
+        }).then(function () {
+            return exec('node index.js', options);
+        }).then(function (result) {
+            t.ok(result, 'ok, got execution result');
+            t.notOk(result && result.stderr, 'ok, execution result should not have stderr');
+            t.end();
+        }).catch(function onerr(err) {
+            t.error(err);
             t.end();
         });
     });


### PR DESCRIPTION
Before this change, if meddleware was deployed outside the app's directory, it was not able to resolve middleware modules deployed under app's node_modules directory.

This change fixes that by adding app's node_modules folder to the `paths` for `require.resolve`.

Added unit test for testing this scenario.